### PR TITLE
Disable resin sync and resin delta tests 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* 	Disable resin sync and resin delta tests from example QEMU and RaspberryPi test cases until they are fixed in Resin 2.0 [Praneeth]
 * 	Pin version of Base image in Dockerfile and python libraries installed with pip [Praneeth]
 * 	Unify instuctions for QEMU 64bit and 32bit images [Horia]
 * 	Test case to verify delta to a running supervisor [Horia]

--- a/qemu.robot
+++ b/qemu.robot
@@ -49,10 +49,10 @@ Check if device is running the pushed application (Tries for 300 s)
   Wait Until Keyword Succeeds    30x    10s    Device "${device_uuid}" log should contain "Hello"
 Check if kernel module loading works
   Check if kernel module loading works on "${device_uuid}"
-Check delta to a running supervisor
-  Check enabling supervisor delta on "${application_name}"
-Check if resin sync works
-  Check if resin sync works on "${device_uuid}"
+#Check delta to a running supervisor
+#  Check enabling supervisor delta on "${application_name}"
+#Check if resin sync works
+#  Check if resin sync works on "${device_uuid}"
 Check if setting environment variable works
   Check if setting environment variables works on "${application_name}"
 Verify if host OS version of the image is same through resin cli

--- a/raspberrypi3.robot
+++ b/raspberrypi3.robot
@@ -52,10 +52,10 @@ Check if device is running the pushed application (Tries for 300 s)
   Wait Until Keyword Succeeds    30x    10s    Device "${device_uuid}" log should contain "Hello"
 Check if kernel module loading works
   Check if kernel module loading works on "${device_uuid}"
-Check delta to a running supervisor
-  Check enabling supervisor delta on "${application_name}"
-Check if resin sync works
-  Check if resin sync works on "${device_uuid}"
+#Check delta to a running supervisor
+#  Check enabling supervisor delta on "${application_name}"
+#Check if resin sync works
+#  Check if resin sync works on "${device_uuid}"
 Check if setting environment variable works
   Check if setting environment variables works on "${application_name}"
 Verify if host OS version of the image is same through resin cli


### PR DESCRIPTION
Disable from example QEMU and Raspbe…rryPi test cases until they are fixed in Resin 2.0 - Until all issues are resolved. This moves the #30 and #31 back into - in-progress.