### PR TITLE
Tests should fail properly if environment variables are not provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* 	Fixing tests to fail properly if environment variables are not provided [Horia]
 * 	Disable resin sync and resin delta tests from example QEMU and RaspberryPi test cases until they are fixed in Resin 2.0 [Praneeth]
 * 	Pin version of Base image in Dockerfile and python libraries installed with pip [Praneeth]
 * 	Unify instuctions for QEMU 64bit and 32bit images [Horia]

--- a/qemu.robot
+++ b/qemu.robot
@@ -9,6 +9,7 @@ Suite Teardown    Terminate All Processes    kill=True
 *** Test Cases ***
 Preparing test environment
   Set Suite Variable    ${application_name}    %{application_name}
+  Should Not Be Empty   ${application_name}    msg=application_name variable cannot be blank
   Set Suite Variable    ${device_type}    %{device_type}
   Set Suite Variable    ${RESINRC_RESIN_URL}    %{RESINRC_RESIN_URL}
   Set Suite Variable    ${image}    %{image}

--- a/resources/resincli.robot
+++ b/resources/resincli.robot
@@ -12,7 +12,7 @@ CLI version is "${version}"
     Should Match    ${result.stdout}    ${version}
 
 Resin login with email "${email}" and password "${password}"
-    ${result} =  Run Process    resin login --credentials --email ${email} --password ${password}    shell=yes
+    ${result} =  Run Process    resin login --credentials --email ${email} --password ${password}    shell=yes    timeout=30sec
     Process ${result}
     ${result} =  Run Process    resin whoami |sed '/USERNAME/!d' |sed 's/^.*USERNAME: //'   shell=yes
     Process ${result}
@@ -22,7 +22,7 @@ Add new SSH key with name "${key_name}"
     Remove File    /root/.ssh/id_ecdsa
     ${result} =  Run Process    ssh-keygen -b 521 -t ecdsa -f /root/.ssh/id_ecdsa -N ''    shell=yes
     Process ${result}
-    ${result} =  Run Process    resin keys |grep ${key_name} |cut -d ' ' -f 1   shell=yes
+    ${result} =  Run Process    resin keys |grep -w ${key_name} |cut -d ' ' -f 1   shell=yes
     Log   all output: ${result.stdout}
     Run Keyword If    '${result.stdout}' != 'NULL'    Run Process    resin key rm ${result.stdout} -y   shell=yes
     ${result} =  Run Process    resin key add ${key_name} /root/.ssh/id_ecdsa.pub   shell=yes


### PR DESCRIPTION
* Resolving an issue where test case would fail if they are keys with almost the same name in resin keys by selecting only those lines containing matches that form whole words.
@lifeeth @villaseca 