### PR TITLE
API: Fix keyword that fails if duplicate names are found in resin keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* 	Fixing keyword that fails if duplicate names are found in resin keys. Also, adding disclaimer as warning [Horia]
 * 	Changing resin-cli version to v.5.2.4 [Horia]
 * 	Fix Host OS Fingerprint test to work with both Resin OS 1.0 and 2.0 [Praneeth]
 * 	Various fixes due to changes in operating system [Andrei]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The resources directory contains Robot Keyword helpers for ``resincli`` and hard
 
 * Create a `env.list` with all the environment variables needed to run the tests - Please check `env.list.example` for a sample environment file.
 
+    * **WARNING!** The application name given needs to be unique as the test suite will delete and recreate any existing application and key of the same name in the settings.
+
 * Load the KVM module
 
 * Execute the following to run an example test against the resin-qemux86 or resin-qemux86-64 image you just downloaded.
@@ -46,6 +48,8 @@ The resources directory contains Robot Keyword helpers for ``resincli`` and hard
 * Create a `env.list` with all the environment variables needed to run the tests - Please check `env.list.example` for a sample environment file.
 
 	* Please make sure that the ``rig_device_id``, ``rig_sd_card`` match your rig's FTDI serial, the SD card path respectively
+
+    * **WARNING!** The application name given needs to be unique as the test suite will delete and recreate any existing application and key of the same name in the settings.
 
 * Execute the following to run an example test against the raspberrypi3 image you just downloaded.
 

--- a/resources/resincli.robot
+++ b/resources/resincli.robot
@@ -17,9 +17,12 @@ Add new SSH key with name "${key_name}"
     Remove File    /root/.ssh/id_ecdsa
     ${result} =  Run Process    ssh-keygen -b 521 -t ecdsa -f /root/.ssh/id_ecdsa -N ''    shell=yes
     Process ${result}
-    ${result} =  Run Process    resin keys |grep -w ${key_name} |cut -d ' ' -f 1   shell=yes
-    Log   all output: ${result.stdout}
-    Run Keyword If    '${result.stdout}' != 'NULL'    Run Process    resin key rm ${result.stdout} -y   shell=yes
+    ${word_count} =  Run Process    resin keys |grep -w ${key_name} |cut -d ' ' -f 1 | wc -l    shell=yes
+    Process ${word_count}
+    :FOR    ${i}    IN RANGE    ${word_count.stdout}
+    \    ${result} =  Run Process    resin keys |grep -w ${key_name} |cut -d ' ' -f 1 | head -1    shell=yes
+    \    Log   all output: ${result.stdout}
+    \    Run Process    resin key rm ${result.stdout} -y    shell=yes
     ${result} =  Run Process    resin key add ${key_name} /root/.ssh/id_ecdsa.pub   shell=yes
     Process ${result}
 


### PR DESCRIPTION
Closes #62 