### PR TITLE
Remove test for resin-info service starting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+*	Remove test for resin-info service starting [Will]
 * 	Fix Host OS version to be agnostic to keywords appened after the OS version [Praneeth]
 * 	Test case that provides a device to the application that already has delta enabled [Horia]
 * 	Fixing keyword that fails if duplicate names are found in resin keys. Also, adding disclaimer as warning [Horia]

--- a/qemu.robot
+++ b/qemu.robot
@@ -41,8 +41,6 @@ Running image
   Set Suite Variable    ${device_qemu_handle}    ${handle}
 Checking if device comes online in 60s (Trying every 10s)
   Wait Until Keyword Succeeds    6x    10s    Device "${device_uuid}" is online
-Checking if resin-info@tty1.service is active
-  Check if service "resin-info@tty1.service" is running using socket "unix\#/tmp/console.sock"
 Git pushing to application
   Git clone "${application_repo}" "/tmp/${application_name}"
   Git checkout "${application_commit}" "/tmp/${application_name}"

--- a/raspberrypi3.robot
+++ b/raspberrypi3.robot
@@ -42,8 +42,6 @@ Running image
   Enable DUT
 Checking if device comes online in 60s (Trying every 10s)
   Wait Until Keyword Succeeds    6x    10s    Device "${device_uuid}" is online
-#Checking if resin-info@tty1.service is active
-#  Check if service "resin-info@tty1.service" is running using socket "unix\#/tmp/console.sock"
 Git pushing to application
   Git clone "${application_repo}" "/tmp/${application_name}"
   Git checkout "${application_commit}" "/tmp/${application_name}"


### PR DESCRIPTION

This service is no longer started in production builds so we can't test for it any more.