### PR TITLE
Bump resin-cli to 7.10.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y qemu-system-x86 rsync qemu-kvm minicom 
     rm -rf /var/lib/apt/lists/* && \
     pip install --upgrade pip && \
     pip install robotframework==3.0 requests==2.4.3 robotframework-requests==0.4.5 pylibftdi==0.15.0 && \
-    npm install --global resin-cli@7.9.0 && \
+    npm install --global resin-cli@7.10.6 && \
     git clone --depth 1  --branch v1.0.0-beta.18 https://github.com/resin-io/etcher.git && cd /etcher && \
     npm install --production && \
     ln -sf /etcher/bin/etcher /usr/local/bin/etcher


### PR DESCRIPTION
This addresses e2e [failed tests](https://jenkins.dev.resin.io/job/balena-e2e-staging/46/console) due to resin sync breaking in older resin sync versions when balena-staging.com is used as the RESINRC_RESIN_URL

Change-type: patch
Signed-off-by: Kostas Lekkas <kostas@balena.io>